### PR TITLE
Fix devtools minor warning

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,19 @@ knitr::opts_chunk$set(
 
 # R wrapper for Van der Maaten's Barnes-Hut implementation of t-Distributed Stochastic Neighbor Embedding 
 
+##Installation
+
+To install from CRAN:
+```{r, eval = FALSE}
+install.packages("Rtsne") # Install Rtsne package from CRAN
+```
+To install the latest version from the github repository, use:
+```{r, eval = FALSE}
+if(!require(devtools)) install.packages("devtools") # If not already installed
+devtools::install_github("jkrijthe/Rtsne")
+```
+
+
 ##Usage
 After installing the package, use the following code to run a simple example (to install, see below).
 ```{r example}
@@ -31,16 +44,6 @@ tsne_out <- Rtsne(as.matrix(iris_unique[,1:4])) # Run TSNE
 plot(tsne_out$Y,col=iris$Species) # Plot the result
 ```
 
-To install from CRAN:
-```{r, eval = FALSE}
-install.packages("Rtsne") # Install Rtsne package from CRAN
-```
-To install the latest version from the github repository, use:
-```{r, eval = FALSE}
-install.packages("devtools") # If not already installed
-library(devtools)
-install_github("Rtsne","jkrijthe")
-```
 
 #Details
 This R package offers a wrapper around the Barnes-Hut TSNE C++ implementation of [2] [3]. Only minor changes were made to the original code to allow it to function as an R package.


### PR DESCRIPTION
Fixes warning:
Username parameter is deprecated. Please use jkrijthe/Rtsne 

Also moved installation to the top.