### PR TITLE
Optimisation: move duplication test after pca reduction

### DIFF
--- a/R/Rtsne.R
+++ b/R/Rtsne.R
@@ -79,15 +79,15 @@ Rtsne.default <- function(X, dims=2, initial_dims=50, perplexity=30, theta=0.5, 
   
   is.wholenumber <- function(x, tol = .Machine$double.eps^0.5)  abs(x - round(x)) < tol
   if (!is.wholenumber(initial_dims) || initial_dims<=0) { stop("Incorrect initial dimensionality.")}
-  if (check_duplicates & !is_distance){
-    if (any(duplicated(X))) { stop("Remove duplicates before running TSNE.") }
-  }
   
   # Apply PCA
   if (pca & !is_distance) {
     pca_result <- prcomp(X,retx=TRUE)
     X <- pca_result$x[,1:min(initial_dims,ncol(pca_result$x))]
   }
+  if (check_duplicates & !is_distance){
+    if (any(duplicated(X))) { stop("Remove duplicates before running TSNE.") }
+  }  
   # Compute Squared distance if we are using exact TSNE
   if (is_distance & theta==0.0) {
     X <- X^2


### PR DESCRIPTION
Here's a PR that offers an optimisation for cases where `ncol(x)` is much bigger than `initial_dims`. It's based on timings provided by @ococrook.

### The data

A matrix of dimensions 500 by 50000.

```r
> set.seed(1L)
> x0 <- matrix(sapply(1:500,
+                    function(x) rnorm(50000, mean = x, sd = 0.3)),
+              ncol = 500)
> x0 <- t(x0)
> set.seed(1L)
> x <- matrix(sapply(1:500,
+                    function(x) rnorm(50000, mean = x, sd = 0.3)),
+              ncol = 500)
> x <- t(x)
> dim(x)
[1]   500 50000
```

### Current `Rtnse` timings

```r
> library("devtools")
> install_github("jkrijthe/Rtsne")
Skipping install of 'Rtsne' from a github remote, the SHA1 (6ee49e92) has not changed since last install.
  Use `force = TRUE` to force installation
> library("Rtsne")
> set.seed(123L)
> (t0 <- system.time(res0 <- Rtsne(x)))
   user  system elapsed 
103.080   1.640 105.038 
```

### Proposed patch timings

```r
> install_github("lgatto/Rtsne")
Downloading GitHub repo lgatto/Rtsne@master
from URL https://api.github.com/repos/lgatto/Rtsne/zipball/master
Installing Rtsne
'/usr/local/lib64/R/bin/R' CMD INSTALL '/tmp/RtmpbbwBPc/devtools2cc17901f6e0/lgatto-Rtsne-ae58114' 
g++  -I/usr/local/lib64/R/include -DNDEBUG  -I"/home/lg390/R/x86_64-pc-linux-gnu-library/3.4/Rcpp/include" -I/usr/local/include   -fpic   -c RcppExports.cpp -o RcppExports.o
g++  -I/usr/local/lib64/R/include -DNDEBUG  -I"/home/lg390/R/x86_64-pc-linux-gnu-library/3.4/Rcpp/include" -I/usr/local/include   -fpic   -c Rtsne.cpp -o Rtsne.o
g++  -I/usr/local/lib64/R/include -DNDEBUG  -I"/home/lg390/R/x86_64-pc-linux-gnu-library/3.4/Rcpp/include" -I/usr/local/include   -fpic   -c sptree.cpp -o sptree.o
g++  -I/usr/local/lib64/R/include -DNDEBUG  -I"/home/lg390/R/x86_64-pc-linux-gnu-library/3.4/Rcpp/include" -I/usr/local/include   -fpic   -c tsne.cpp -o tsne.o
g++ -shared -L/usr/local/lib64/R/lib -L/usr/local/lib64 -o Rtsne.so RcppExports.o Rtsne.o sptree.o tsne.o -llapack -lf77blas -latlas -lgfortran -lm -lquadmath -L/usr/local/lib64/R/lib -lR
Reloading installed Rtsne
> set.seed(123L)
> (t1 <- system.time(res1 <- Rtsne(x)))
   user  system elapsed 
 28.388   1.064  29.472 
```

### Checking results are identical

```r
> identical(res0, res0)
[1] TRUE
```

### Improvement

The optimisation comes from checking duplicated rows after running PCA and subsetting columns to `1:min(initial_dims, ncol(pca_result$x))`, rather than all columns.

```r
> t0 - t1
   user  system elapsed 
 74.692   0.576  75.566 
> system.time(any(duplicated(x)))
   user  system elapsed 
 65.869   0.153  66.001 
> system.time(any(duplicated(x[, 1:50])))
   user  system elapsed 
  0.068   0.000   0.068 
```

There won't be any or limited improvements when `ncol(x) <= inital_dims` or when `Rtsne_cpp` takes much more time that checking for duplicated rows.